### PR TITLE
Fix handling of hardcoded query strings in URL paths

### DIFF
--- a/Restless/Classes/DRProtocolImpl.m
+++ b/Restless/Classes/DRProtocolImpl.m
@@ -83,7 +83,7 @@ typedef void (^DRCallback)(id result, NSURLResponse *response, NSError* error);
 		return;
 	}
 	
-	NSURL* fullPath = [self.endPoint URLByAppendingPathComponent:pathParamResult.result];
+	NSURL* fullPath = [NSURL URLWithString:pathParamResult.result relativeToURL:self.endPoint];
 	[consumedParameters unionSet:pathParamResult.consumedParameters];
 	
 	NSLog(@"full path: %@", fullPath);

--- a/RestlessTests/GitHubService.h
+++ b/RestlessTests/GitHubService.h
@@ -18,6 +18,10 @@
 - (NSURLSessionDataTask*)listRepos:(NSString*)user
 						  callback:DR_CALLBACK(NSArray<GitHubRepo*>*)callback;
 
+@GET("/users/{user}/repos?sort=desc")
+- (NSURLSessionDataTask*)listReposDesc:(NSString*)user
+                              callback:DR_CALLBACK(NSArray<GitHubRepo*>*)callback;
+
 @GET("/users/{user}/wikis")
 - (NSURLSessionDataTask*)listWikis:(NSString*)user
 						  fromDate:(NSDate*)date

--- a/RestlessTests/RestlessTests.m
+++ b/RestlessTests/RestlessTests.m
@@ -130,4 +130,23 @@
 	}];
 }
 
+- (void)testBuildURLWithHardcodedQuery {
+    DRRestAdapter* ra = [DRRestAdapter restAdapterWithBlock:^(DRRestAdapterBuilder *builder) {
+        builder.endPoint = [NSURL URLWithString:@"https://api.github.com"];
+        builder.bundle = [NSBundle bundleForClass:[DRRestAdapter class]];
+    }];
+
+    NSObject<GitHubService>* service = [ra create:@protocol(GitHubService)];
+
+    NSURLSessionDataTask* task = [service listReposDesc:@"natep" callback:^(NSArray *result, NSURLResponse *response, NSError *error) {}];
+
+    NSArray* items = [[NSURLComponents alloc] initWithURL:task.originalRequest.URL resolvingAgainstBaseURL:NO].queryItems;
+    XCTAssertEqual(items.count, 1);
+
+    NSURLQueryItem* item = items.firstObject;
+
+    XCTAssertEqualObjects(item.name, @"sort");
+    XCTAssertEqualObjects(item.value, @"desc");
+}
+
 @end


### PR DESCRIPTION
A more general fix for the query escaping problem that @diachini reported in #9.
